### PR TITLE
Update actions/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,9 @@
       }
     },
     "@actions/core": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.5.tgz",
-      "integrity": "sha512-mwpoNjHSWWh0IiALdDEQi3tru124JKn0yVNziIBzTME8QRv7thwoghVuT1jBRjFvdtoHsqD58IRHy1nf86paRg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/exec": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@actions/cache": "^1.0.2",
-        "@actions/core": "^1.2.5",
+        "@actions/core": "^1.2.6",
         "@actions/github": "^4.0.0",
         "@actions/io": "^1.0.2",
         "@actions/tool-cache": "^1.6.0",


### PR DESCRIPTION
Per the announcement on https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ I've upgraded the `@actions/core` to 1.2.6 to bring back the `addPath` function.